### PR TITLE
precondition test main module

### DIFF
--- a/TU-Agent/agentKnowledge.pl
+++ b/TU-Agent/agentKnowledge.pl
@@ -55,6 +55,8 @@ readUpgrades.
 % Beliefs for upgrades.	
 upgrades([]).
 upgraded([]).
+% Knowledge about the size of a list
+empty(L) :- length(L, 0).
 
 
 

--- a/TU-Agent/test.test2g
+++ b/TU-Agent/test.test2g
@@ -7,7 +7,15 @@ use tygron as actionspec.
 timeout = 30.
 
 test tygron with
-	pre {goal(indicatorGoal(_, _))}
+	pre {
+		%We should have at least an indicatorGoal for this module to run
+		goal(indicatorGoal(_, _)),
+		%Tests for some important believes which are needed for this module to function.
+		bel(functions(FunctionsList), not(empty(FunctionsList))),
+		bel(stakeholders(StakeholdersList), not(empty(StakeholdersList))),
+		bel(buildings(BuildingsList), not(empty(BuildingsList))),
+		bel(indicators(IndicatorsList), not(empty(IndicatorsList)))
+		}
 	in {
 		%Percept tests%
 		%We only percept this only once because of the empty list believe.

--- a/TU-Agent/tygronInit.mod2g
+++ b/TU-Agent/tygronInit.mod2g
@@ -21,9 +21,7 @@ module tygronInit {
 	if true 
 		then insert(actions([])).
 	if true 
-		then insert(upgradeTypes([])).	
-	if true 
-		then insert(actions([])).	
+		then insert(upgradeTypes([])).		
 	if true 
 		then insert(noOldBuildings).
 }


### PR DESCRIPTION
added the empty list knowledge
removed the duplicate initial action believe
As far as i know, having multiple seperate conditions in the precondition of a test is not possible. So i solved it like this for the moment.

As a developer
I want to test all of my code
so that I'm sure that it works properly
