### PR TITLE
Request fix

### DIFF
--- a/TU-Agent/handleRequest.mod2g
+++ b/TU-Agent/handleRequest.mod2g
@@ -24,7 +24,7 @@ module handleRequest {
 	forall bel(requests(X), member(request(_, Category, PopupID, _, _, _, _, _, _, _), X), not(requestAnswered(Category, PopupID)))
 		do popup_answer(PopupID, 0) + insert(requestAnswered(Category, PopupID)).
 	
-	% If a popup was removed from the requests list, but we havn't answered it, this rule will prevent loops
+	% If a popup was removed from the requests list, but we have not answered it, this rule will prevent loops
 	forall goal(answerRequest(Category, PopupID))
 		do popup_answer(PopupID, 0) + insert(requestAnswered(Category, PopupID)).
 }

--- a/TU-Agent/handleRequest.mod2g
+++ b/TU-Agent/handleRequest.mod2g
@@ -25,6 +25,6 @@ module handleRequest {
 		do popup_answer(PopupID, 0) + insert(requestAnswered(Category, PopupID)).
 	
 	% If a popup was removed from the requests list, but we havn't answered it, this rule will prevent loops
-	forall bel(not(requestAnswered(Category, PopupID)))
+	forall goal(answerRequest(Category, PopupID))
 		do popup_answer(PopupID, 0) + insert(requestAnswered(Category, PopupID)).
 }

--- a/TU-Agent/handleRequest.mod2g
+++ b/TU-Agent/handleRequest.mod2g
@@ -1,30 +1,30 @@
 use agentKnowledge as knowledge.
 use tygron as actionspec.
 
-order=linear.
+order=linearall.
 
 module handleRequest {
 	% Accept (ActionID = 0) a request to buy land if the indicator goal of building high buildings has been satisfied and the price is acceptable
-	if bel(requests(X), member(request(_, 'BUY_LAND', PopupID, _, _, _, Price, _, Area, _), X), isNumber(Price), acceptablePrice(Price, Area), not(requestAnswered('BUY_LAND', PopupID))), not(goal(indicatorGoal('Bouwen hoge gebouwen', _)))
-		then popup_answer(PopupID, 0) + insert(requestAnswered('BUY_LAND', PopupID)).
+	forall bel(requests(X), member(request(_, 'BUY_LAND', PopupID, _, _, _, Price, _, Area, _), X), isNumber(Price), acceptablePrice(Price, Area), not(requestAnswered('BUY_LAND', PopupID))), not(goal(indicatorGoal('Bouwen hoge gebouwen', _)))
+		do popup_answer(PopupID, 0) + insert(requestAnswered('BUY_LAND', PopupID)).
 		
 	% Decline (ActionID = 1) a request to buy land if there is a plan to build (on that land)
-	if bel(requests(X), member(request(_, 'BUY_LAND', PopupID, _, _, _, Price, _, _, _), X), isNumber(Price), not(requestAnswered('BUY_LAND', PopupID)))
-		then popup_answer(PopupID, 1) + insert(requestAnswered('BUY_LAND', PopupID)).
+	forall bel(requests(X), member(request(_, 'BUY_LAND', PopupID, _, _, _, Price, _, _, _), X), isNumber(Price), not(requestAnswered('BUY_LAND', PopupID)))
+		do popup_answer(PopupID, 1) + insert(requestAnswered('BUY_LAND', PopupID)).
 		
 	% Answer all permit popups with a date with yes (ActionID = 0)
-	if bel(requests(X), member(request('INTERACTION_WITH_DATE', 'PERMIT', PopupID, _, _, _, _, _, _, _), X), not(requestAnswered(Category, PopupID)))
-		then popup_answer_with_date(PopupID, 0, 0) + insert(requestAnswered('PERMIT', PopupID)).
+	forall bel(requests(X), member(request('INTERACTION_WITH_DATE', 'PERMIT', PopupID, _, _, _, _, _, _, _), X), not(requestAnswered(Category, PopupID)))
+		do popup_answer_with_date(PopupID, 0, 0) + insert(requestAnswered('PERMIT', PopupID)).
 	
 	% Answer all permit popups with yes (ActionID = 0) since that is the only option
-	if bel(requests(X), member(request('INFORMATION', 'PERMIT', PopupID, _, _, _, _, _, _, _), X), not(requestAnswered(Category, PopupID)))
-		then popup_answer(PopupID, 0) + insert(requestAnswered('PERMIT', PopupID)).
+	forall bel(requests(X), member(request('INFORMATION', 'PERMIT', PopupID, _, _, _, _, _, _, _), X), not(requestAnswered(Category, PopupID)))
+		do popup_answer(PopupID, 0) + insert(requestAnswered('PERMIT', PopupID)).
 		
 	% Catch any requests that do not fall under any of the preconditions of the previous actions and answer yes (ActionID = 0))
-	if bel(requests(X), member(request(_, Category, PopupID, _, _, _, _, _, _, _), X), not(requestAnswered(Category, PopupID)))
-		then popup_answer(PopupID, 0) + insert(requestAnswered(Category, PopupID)).
-		
-	% If the module is erronously called with an empty list, exit the module	
-	if bel(requests(X), empty(X))
-		then exit-module.
+	forall bel(requests(X), member(request(_, Category, PopupID, _, _, _, _, _, _, _), X), not(requestAnswered(Category, PopupID)))
+		do popup_answer(PopupID, 0) + insert(requestAnswered(Category, PopupID)).
+	
+	% If a popup was removed from the requests list, but we havn't answered it, this rule will prevent loops
+	forall bel(not(requestAnswered(Category, PopupID)))
+		do popup_answer(PopupID, 0) + insert(requestAnswered(Category, PopupID)).
 }

--- a/TU-Agent/tygron.act2g
+++ b/TU-Agent/tygron.act2g
@@ -38,15 +38,15 @@ define building_plan_upgrade(UpgradeID, MultiPolygon) with
 	
 % Define the answer to a popup action
 % Answer another stakeholders request
-% params = RequestID, AnswerID
+% params = PopupID, AnswerID
 define popup_answer(PopupID, AnswerID) with
   pre{not(requestAnswered(_, PopupID))}
   post{ requestAnswered(PopupID, AnswerID) } 
   
 % Define the answer to a popup with a date action
 % Answer another stakeholders request
-% params = RequestID, AnswerID, Date
-define popup_answer_with_date(RequestID, AnswerID, Date) with
+% params = PopupID, AnswerID, Date
+define popup_answer_with_date(PopupID, AnswerID, Date) with
   pre{not(requestAnswered(_, PopupID))}
   post{ requestAnswered(PopupID, AnswerID) } 
 

--- a/TU-Agent/tygron.act2g
+++ b/TU-Agent/tygron.act2g
@@ -39,16 +39,17 @@ define building_plan_upgrade(UpgradeID, MultiPolygon) with
 % Define the answer to a popup action
 % Answer another stakeholders request
 % params = RequestID, AnswerID
-define popup_answer(RequestID, AnswerID) with
-  pre{ requests(X), not(empty(X)) }
-  post{ requestAnswered(RequestID, AnswerID) } 
+define popup_answer(PopupID, AnswerID) with
+  pre{not(requestAnswered(_, PopupID))}
+  post{ requestAnswered(PopupID, AnswerID) } 
   
 % Define the answer to a popup with a date action
 % Answer another stakeholders request
 % params = RequestID, AnswerID, Date
 define popup_answer_with_date(RequestID, AnswerID, Date) with
-  pre{ requests(X), not(empty(X)) }
-  post{ requestAnswered(RequestID, AnswerID) } 
+  pre{not(requestAnswered(_, PopupID))}
+  post{ requestAnswered(PopupID, AnswerID) } 
+
 %Custom actions
 
 %This returns relevant areas from the tygron environment.

--- a/TU-Agent/tygronEvents.mod2g
+++ b/TU-Agent/tygronEvents.mod2g
@@ -24,8 +24,8 @@ module tygronEvents {
 		then delete(upgradeTypes(Y)) + insert(upgradeTypes(X)).
 		
 	%Add the goal of answering a request every time the agent receives one
-	if bel(requests(X), not(empty(X)), member(request(Type, Category, PopupID, ContentlinkID, VisibleStakeholderIDs, ActionLogIDS, Price, Multipolygon, AreaSize, Answers), X))
-		then adopt(answerRequest(Category, PopupID)).
+	forall bel(requests(X), not(empty(X)), member(request(Type, Category, PopupID, ContentlinkID, VisibleStakeholderIDs, ActionLogIDS, Price, Multipolygon, AreaSize, Answers), X))
+		do adopt(answerRequest(Category, PopupID)).
 
 	%Custom actions percepts
 	%If we have no believe about this CallID insert it


### PR DESCRIPTION
Speeds up and fix the request loop.
Problem was that if a request wasn't answered for some time it was removed from the requests percept list, but wasn't answered yet. Added an extra line to solve this IF it happens, but its unlikely to happen now that forall/linearall speeds things up.

As an agent I want to handle requests 
so I can interact with other stakeholders
