### PR TITLE
Goal adoption enhancement

### DIFF
--- a/TU-Agent/agentGoals.pl
+++ b/TU-Agent/agentGoals.pl
@@ -1,1 +1,0 @@
-getIndicatorGoals.

--- a/TU-Agent/agentKnowledge.pl
+++ b/TU-Agent/agentKnowledge.pl
@@ -20,8 +20,6 @@
 :- dynamic relevant_areas/2.
 
 %The goals and how to achieve them.
-%we have to retrieve this only once and the goal will be dropped by hand
-getIndicatorGoals :- false.
 %an indicatorgoal is met if the current score is the target score
 indicatorGoal(Name, Target) :- indicator(_, Name, Current, _), Target > 0, Current >= Target.
 indicatorGoal(Name, Target) :- indicator(_, Name, Current, _), Target =< 0, Current =< Target.

--- a/TU-Agent/test.test2g
+++ b/TU-Agent/test.test2g
@@ -72,8 +72,7 @@ test tygron with
 		%The goal should be reconsidered and dropped because of the believe, according to template G2.
 		bel(relevant_areas(0, MPList), not(empty(MPList))) 
 			leadsto not(goal(createLandToBuild)).
-		bel(indicator(_, Name, _, Target)), goal(getIndicatorGoals) 
-			leadsto goal(indicatorGoal(Name, Target)).
+			
 		%The believe is the reason for not having the goal here, according to template G3.
 		never goal(indicatorGoal(Name, Target)), bel(indicator(_, Name, Current, _), Target > 0, Current >= Target). 
 		never goal(indicatorGoal(Name, Target)), bel(indicator(_, Name, Current, _), Target =< 0, Current =< Target).	

--- a/TU-Agent/test.test2g
+++ b/TU-Agent/test.test2g
@@ -71,7 +71,7 @@ test tygron with
 		%Goal tests%
 		%The goal should be reconsidered and dropped because of the believe, according to template G2.
 		bel(relevant_areas(0, MPList), not(empty(MPList))) 
-			leadsto not(goal(createLandToBuild)).
+			leadsto not(goal(createLandToBuild)).		
 			
 		%The believe is the reason for not having the goal here, according to template G3.
 		never goal(indicatorGoal(Name, Target)), bel(indicator(_, Name, Current, _), Target > 0, Current >= Target). 

--- a/TU-Agent/tygronEvents.mod2g
+++ b/TU-Agent/tygronEvents.mod2g
@@ -44,11 +44,7 @@ module tygronEvents {
 		do delete(indicator(IndicatorID, Name, OldCurrent, Target)) + insert(indicator(IndicatorID, Name, Current, Target)).
 	
 	%set up the goals for the indicators
-	forall bel(indicator(_, Name, _, Target)), goal(getIndicatorGoals)
+	%if we don't have the goal, and the goal isn't achieved either, we should adopt it.
+	forall bel(indicator(_, Name, _, Target)), not(goal-a(indicatorGoal(Name, Target)))
 		do adopt(indicatorGoal(Name, Target)).
-	
-	%we can drop this after the first run%
-	%we can't seem to fix this by placing it in the init module""
-	if goal(getIndicatorGoals)
-		then drop(getIndicatorGoals).
 }

--- a/TU-Agent/tygronEvents.mod2g
+++ b/TU-Agent/tygronEvents.mod2g
@@ -45,6 +45,6 @@ module tygronEvents {
 	
 	%set up the goals for the indicators
 	%if we don't have the goal, and the goal isn't achieved either, we should adopt it.
-	forall bel(indicator(_, Name, _, Target)), not(goal-a(indicatorGoal(Name, Target)))
+	forall bel(indicator(_, Name, _, Target)), not(goal(indicatorGoal(Name, Target)))
 		do adopt(indicatorGoal(Name, Target)).
 }


### PR DESCRIPTION
This should fix issue #56.
Also makes sure that when a goal is dropped, but later in the simulation the current score falls below the target score, it will be adopted again.

As an agent
I want to adopt goals according
to the indicators so that i can
improve my score.
