### PR TITLE
Goal adoption enhancement

### DIFF
--- a/TU-Agent/agentGoals.pl
+++ b/TU-Agent/agentGoals.pl
@@ -1,1 +1,0 @@
-getIndicatorGoals.

--- a/TU-Agent/agentKnowledge.pl
+++ b/TU-Agent/agentKnowledge.pl
@@ -25,8 +25,6 @@
 :- dynamic relevant_areas/2.
 
 %The goals and how to achieve them.
-%we have to retrieve this only once and the goal will be dropped by hand
-getIndicatorGoals :- false.
 %an indicatorgoal is met if the current score is the target score
 indicatorGoal(Name, Target) :- indicator(_, Name, Current, _), Target > 0, Current >= Target.
 indicatorGoal(Name, Target) :- indicator(_, Name, Current, _), Target =< 0, Current =< Target.

--- a/TU-Agent/buildConstruction.test2g
+++ b/TU-Agent/buildConstruction.test2g
@@ -1,6 +1,5 @@
 use TUAgent as mas.
 use agentKnowledge as knowledge.
-use agentGoals as goals.
 use buildConstruction as module.
 use tygron as actionspec.
 

--- a/TU-Agent/buildGreen.test2g
+++ b/TU-Agent/buildGreen.test2g
@@ -1,6 +1,5 @@
 use TUAgent as mas.
 use agentKnowledge as knowledge.
-use agentGoals as goals.
 use buildGreen as module.
 use tygron as actionspec.
 

--- a/TU-Agent/demolish.test2g
+++ b/TU-Agent/demolish.test2g
@@ -1,6 +1,5 @@
 use TUAgent as mas.
 use agentKnowledge as knowledge.
-use agentGoals as goals.
 use demolish as module.
 use tygron as actionspec.
 

--- a/TU-Agent/handleRequest.test2g
+++ b/TU-Agent/handleRequest.test2g
@@ -1,6 +1,5 @@
 use TUAgent as mas.
 use agentKnowledge as knowledge.
-use agentGoals as goals.
 use handleRequest as module.
 use tygron as actionspec.
 

--- a/TU-Agent/test.test2g
+++ b/TU-Agent/test.test2g
@@ -1,6 +1,5 @@
 use TUAgent as mas.
 use agentKnowledge as knowledge.
-use agentGoals as goals.
 use tygron as module.
 use tygron as actionspec.
 
@@ -71,9 +70,8 @@ test tygron with
 		%Goal tests%
 		%The goal should be reconsidered and dropped because of the believe, according to template G2.
 		bel(relevant_areas(0, MPList), not(empty(MPList))) 
-			leadsto not(goal(createLandToBuild)).
-		bel(indicator(_, Name, _, Target)), goal(getIndicatorGoals) 
-			leadsto goal(indicatorGoal(Name, Target)).
+			leadsto not(goal(createLandToBuild)).		
+			
 		%The believe is the reason for not having the goal here, according to template G3.
 		never goal(indicatorGoal(Name, Target)), bel(indicator(_, Name, Current, _), Target > 0, Current >= Target). 
 		never goal(indicatorGoal(Name, Target)), bel(indicator(_, Name, Current, _), Target =< 0, Current =< Target).	

--- a/TU-Agent/tygronEvents.mod2g
+++ b/TU-Agent/tygronEvents.mod2g
@@ -45,11 +45,9 @@ module tygronEvents {
 	
 	%We can't adopt goals in the init module
 	%set up the goals for the indicators
-	forall bel(indicator(_, Name, _, Target)), goal(getIndicatorGoals)
+	%if we don't have the goal, and the goal isn't achieved either, we should adopt it.
+	forall bel(indicator(_, Name, _, Target)), not(goal(indicatorGoal(Name, Target)))
 		do adopt(indicatorGoal(Name, Target)).
-	%we can drop this after the first run%
-	if goal(getIndicatorGoals)
-		then drop(getIndicatorGoals).
 		
 	%increase the cycle
 	if bel(cycle(X), increase(X, Y))


### PR DESCRIPTION
This should fix issue #56.
Also makes sure that when a goal is dropped, but later in the simulation the current score falls below the target score, it will be adopted again.

As an agent
I want to adopt goals according
to the indicators so that i can
improve my score.
